### PR TITLE
Fix home page alignment

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -14,5 +14,5 @@ export default function MarkdownRenderer({
   const html = parse(markdown);
   const reactElement = htmlToReactParser.parse(html);
 
-  return <div className="prose">{reactElement}</div>;
+  return <div className="prose text-center">{reactElement}</div>;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -183,7 +183,7 @@ const Home = () => {
                   }}
                 />
               )}
-              <div className="w-4/5 items-center">
+              <div className="flex w-4/5 flex-col items-center">
                 <h1 className="mb-12 text-center text-3xl font-medium">
                   {pageData.mdTitle}
                 </h1>


### PR DESCRIPTION
Fix: home page description text under title isn't centered