### PR TITLE
Added Verification Log Model and Actions

### DIFF
--- a/src/server/db/actions/VerificationLogAction.ts
+++ b/src/server/db/actions/VerificationLogAction.ts
@@ -28,7 +28,7 @@ type VerificationLogVerificationParams = z.infer<
 >;
 
 /**
- * Create a verification log for an email. If a verification log already exists for the email, it is deleted.
+ * Create a verification log for an email. Pre-existing verification logs for the same email and type are deleted.
  * @param email Email of the user
  * @param token Token to be sent to the user for verification later
  * @param type Type of verification log (e.g. password reset, email verification)
@@ -62,6 +62,7 @@ const createVerificationLog = async ({
 /**
  * Verify a verification log for an email. If the token is verified, the verification log is deleted.
  * If the token is incorrect and @decrementAttempts is set, the number of attempts remaining is decremented.
+ * If the number of attempts remaining reaches 0, the verification log is deleted to prevent brute-forcing the token.
  * @param email Email of the user
  * @param type Type of verification log (e.g. password reset, email verification)
  * @param token Token to verify
@@ -105,7 +106,7 @@ const verifyVerificationLog = async ({
 };
 
 /**
- * Create a password reset log for an email.
+ * Create a password reset log for an email. Pre-existing password reset logs for the same email are deleted.
  * @param email Email of the user
  * @returns Verification log object
  */
@@ -125,7 +126,8 @@ export const createPasswordResetLog = async (
 };
 
 /**
- * Verify a password reset log for an email.
+ * Verify a password reset log for an email. If the token is verified, the password reset log is deleted.
+ * If the token is incorrect, the number of attempts remaining is decremented. If the number of attempts remaining reaches 0, the password reset log is deleted to prevent brute-forcing the token.
  * @param email Email of the user
  * @param token Token to verify
  * @returns Whether the token is verified
@@ -144,7 +146,7 @@ export const verifyPasswordResetLog = async (
 };
 
 /**
- * Create an email verification log for an email.
+ * Create an email verification log for an email. Pre-existing email verification logs for the same email are deleted.
  * @param email Email of the user
  * @returns Verification log object
  */

--- a/src/server/db/actions/VerificationLogAction.ts
+++ b/src/server/db/actions/VerificationLogAction.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
 import { generateRandomNumberSequence } from "@/utils/misc";
@@ -153,14 +152,15 @@ export const verifyPasswordResetLog = async (
 export const createEmailVerificationLog = async (
   email: string,
 ): Promise<IVerificationLog> => {
-  const token: string = uuidv4();
+  const otp: string = generateRandomNumberSequence(6);
   const expiresAt: Date = new Date(
     new Date().getTime() + 7 * 24 * 60 * 60 * 1000,
   ); // 7 days from now
   const emailVerificationLog = await createVerificationLog({
     email,
     type: VerificationLogType.EMAIL_VERIFICATION,
-    token,
+    token: otp,
+    numAttempts: 20,
     expiresAt,
   });
   return emailVerificationLog;

--- a/src/server/db/actions/VerificationLogAction.ts
+++ b/src/server/db/actions/VerificationLogAction.ts
@@ -1,0 +1,183 @@
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+
+import { generateRandomNumberSequence } from "@/utils/misc";
+import { verificationLogSchema, VerificationLogType } from "@/utils/types";
+import VerificationLogModel, {
+  IVerificationLog,
+} from "../models/VerificationLogModel";
+import connectMongoDB from "../mongodb";
+import { VerificationLogDoesNotExistException } from "@/utils/exceptions/verificationLog";
+
+const verificationLogCreationParams = verificationLogSchema
+  .omit({ numAttemptsRemaining: true, createdAt: true })
+  .extend({ numAttempts: z.number().int().optional() });
+const verificationLogVerificationParams = verificationLogSchema
+  .omit({
+    numAttemptsRemaining: true,
+    createdAt: true,
+    expiresAt: true,
+  })
+  .extend({ decrementAttempts: z.boolean().optional() });
+
+type VerificationLogCreationParams = z.infer<
+  typeof verificationLogCreationParams
+>;
+type VerificationLogVerificationParams = z.infer<
+  typeof verificationLogVerificationParams
+>;
+
+/**
+ * Create a verification log for an email. If a verification log already exists for the email, it is deleted.
+ * @param email Email of the user
+ * @param token Token to be sent to the user for verification later
+ * @param type Type of verification log (e.g. password reset, email verification)
+ * @param expiresAt Expiry date of the token
+ * @param numAttempts Number of attempts allowed to verify the token before it is deleted
+ * @returns Verification log object
+ */
+const createVerificationLog = async ({
+  email,
+  token,
+  type,
+  expiresAt,
+  numAttempts = -1,
+}: VerificationLogCreationParams): Promise<IVerificationLog> => {
+  await connectMongoDB();
+  await VerificationLogModel.deleteMany({
+    email,
+    type,
+  });
+
+  const verificationLog = await VerificationLogModel.create({
+    email,
+    type,
+    token,
+    numAttemptsRemaining: numAttempts,
+    expiresAt,
+  });
+  return verificationLog.toObject();
+};
+
+/**
+ * Verify a verification log for an email. If the token is verified, the verification log is deleted.
+ * If the token is incorrect and @decrementAttempts is set, the number of attempts remaining is decremented.
+ * @param email Email of the user
+ * @param type Type of verification log (e.g. password reset, email verification)
+ * @param token Token to verify
+ * @param decrementAttempts Whether to decrement the number of attempts remaining in case of incorrect token
+ * @returns Whether the token is verified
+ * @throws {VerificationLogDoesNotExistException} If the verification log does not exist
+ */
+const verifyVerificationLog = async ({
+  email,
+  type,
+  token,
+  decrementAttempts = false,
+}: VerificationLogVerificationParams): Promise<boolean> => {
+  await connectMongoDB();
+  const passwordResetLog = await VerificationLogModel.findOne({
+    email,
+    type,
+  });
+  if (!passwordResetLog) {
+    throw new VerificationLogDoesNotExistException();
+  }
+
+  if (passwordResetLog.token === token) {
+    await passwordResetLog.deleteOne();
+    return true;
+  }
+
+  // Password reset log exists but token provided is incorrect
+
+  // Decrement the number of attempts remaining if the parameter is set
+  // If the number of attempts remaining reaches 0, delete the verification log so that the user cannot brute-force the token
+  if (decrementAttempts) {
+    passwordResetLog.numAttemptsRemaining -= 1;
+    if (passwordResetLog.numAttemptsRemaining === 0) {
+      await passwordResetLog.deleteOne();
+    } else {
+      await passwordResetLog.save();
+    }
+  }
+  return false;
+};
+
+/**
+ * Create a password reset log for an email.
+ * @param email Email of the user
+ * @returns Verification log object
+ */
+export const createPasswordResetLog = async (
+  email: string,
+): Promise<IVerificationLog> => {
+  const otp: string = generateRandomNumberSequence(6);
+  const expiresAt: Date = new Date(new Date().getTime() + 15 * 60 * 1000); // 15 minutes from now
+  const passwordResetLog = await createVerificationLog({
+    email,
+    type: VerificationLogType.PASSWORD_RESET,
+    token: otp,
+    numAttempts: 5,
+    expiresAt,
+  });
+  return passwordResetLog;
+};
+
+/**
+ * Verify a password reset log for an email.
+ * @param email Email of the user
+ * @param token Token to verify
+ * @returns Whether the token is verified
+ * @throws {VerificationLogDoesNotExistException} If the verification log does not exist
+ */
+export const verifyPasswordResetLog = async (
+  email: string,
+  token: string,
+): Promise<boolean> => {
+  return verifyVerificationLog({
+    email,
+    type: VerificationLogType.PASSWORD_RESET,
+    token,
+    decrementAttempts: true,
+  });
+};
+
+/**
+ * Create an email verification log for an email.
+ * @param email Email of the user
+ * @returns Verification log object
+ */
+export const createEmailVerificationLog = async (
+  email: string,
+): Promise<IVerificationLog> => {
+  const token: string = uuidv4();
+  const expiresAt: Date = new Date(
+    new Date().getTime() + 7 * 24 * 60 * 60 * 1000,
+  ); // 7 days from now
+  const emailVerificationLog = await createVerificationLog({
+    email,
+    type: VerificationLogType.EMAIL_VERIFICATION,
+    token,
+    expiresAt,
+  });
+  return emailVerificationLog;
+};
+
+/**
+ * Verify an email verification log for an email.
+ * @param email Email of the user
+ * @param token Token to verify
+ * @returns Whether the token is verified
+ * @throws {VerificationLogDoesNotExistException} If the verification log does not exist
+ */
+export const verifyEmailVerificationLog = async (
+  email: string,
+  token: string,
+): Promise<boolean> => {
+  return verifyVerificationLog({
+    email,
+    type: VerificationLogType.EMAIL_VERIFICATION,
+    token,
+  });
+};

--- a/src/server/db/actions/VerificationLogAction.ts
+++ b/src/server/db/actions/VerificationLogAction.ts
@@ -77,29 +77,29 @@ const verifyVerificationLog = async ({
   decrementAttempts = false,
 }: VerificationLogVerificationParams): Promise<boolean> => {
   await connectMongoDB();
-  const passwordResetLog = await VerificationLogModel.findOne({
+  const verificationLog = await VerificationLogModel.findOne({
     email,
     type,
   });
-  if (!passwordResetLog) {
+  if (!verificationLog) {
     throw new VerificationLogDoesNotExistException();
   }
 
-  if (passwordResetLog.token === token) {
-    await passwordResetLog.deleteOne();
+  if (verificationLog.token === token) {
+    await verificationLog.deleteOne();
     return true;
   }
 
-  // Password reset log exists but token provided is incorrect
+  // Verification log exists but token provided is incorrect
 
   // Decrement the number of attempts remaining if the parameter is set
   // If the number of attempts remaining reaches 0, delete the verification log so that the user cannot brute-force the token
   if (decrementAttempts) {
-    passwordResetLog.numAttemptsRemaining -= 1;
-    if (passwordResetLog.numAttemptsRemaining === 0) {
-      await passwordResetLog.deleteOne();
+    verificationLog.numAttemptsRemaining -= 1;
+    if (verificationLog.numAttemptsRemaining === 0) {
+      await verificationLog.deleteOne();
     } else {
-      await passwordResetLog.save();
+      await verificationLog.save();
     }
   }
   return false;

--- a/src/server/db/models/VerificationLogModel.ts
+++ b/src/server/db/models/VerificationLogModel.ts
@@ -1,0 +1,46 @@
+import {
+  verificationLogSchema,
+  VerificationLogType,
+} from "../../../utils/types";
+import mongoose from "mongoose";
+import { z } from "zod";
+
+const { Schema } = mongoose;
+
+export interface IVerificationLog
+  extends z.infer<typeof verificationLogSchema> {}
+
+const VerificationLogSchema = new Schema<IVerificationLog>({
+  email: {
+    type: mongoose.Schema.Types.String,
+    required: true,
+    unique: true,
+  },
+  type: {
+    type: mongoose.Schema.Types.String,
+    enum: VerificationLogType,
+    required: true,
+  },
+  token: {
+    type: mongoose.Schema.Types.String,
+    default: "",
+  },
+  numAttemptsRemaining: {
+    type: mongoose.Schema.Types.Number,
+    default: -1,
+  },
+  createdAt: {
+    type: mongoose.Schema.Types.Date,
+    default: new Date(),
+  },
+  expiresAt: {
+    type: mongoose.Schema.Types.Date,
+  },
+});
+
+VerificationLogSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const VerificationLogModel =
+  (mongoose.models.VerificationLog as mongoose.Model<IVerificationLog>) ??
+  mongoose.model("VerificationLog", VerificationLogSchema);
+export default VerificationLogModel;

--- a/src/utils/exceptions/verificationLog.ts
+++ b/src/utils/exceptions/verificationLog.ts
@@ -1,0 +1,15 @@
+import { HTTP_STATUS_CODE } from "../consts";
+
+export abstract class VerificationLogException extends Error {
+  code: HTTP_STATUS_CODE;
+  constructor(message: string, code: HTTP_STATUS_CODE) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export class VerificationLogDoesNotExistException extends VerificationLogException {
+  constructor(message = "Verification log does not exist") {
+    super(message, HTTP_STATUS_CODE.NOT_FOUND);
+  }
+}

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,0 +1,15 @@
+import crypto from "crypto";
+
+/**
+ * This function generates a random number sequence of a given length.
+ * For example, if length is 5, the output could be "42985".
+ * @param length the length of the random number sequence
+ * @returns the random number sequence
+ */
+export const generateRandomNumberSequence = (length: number): string => {
+  const res: string[] = [];
+  for (let i = 0; i < length; i++) {
+    res.push(crypto.randomInt(10).toString());
+  }
+  return res.join("");
+};

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -168,6 +168,21 @@ export const contactSchema = z.object({
   userId: z.string().length(24),
 });
 
+// VerificationLog
+export enum VerificationLogType {
+  PASSWORD_RESET = "PASSWORD_RESET",
+  EMAIL_VERIFICATION = "EMAIL_VERIFICATION",
+}
+
+export const verificationLogSchema = z.object({
+  email: z.string().email("Not a valid email"),
+  type: z.nativeEnum(VerificationLogType),
+  token: z.union([z.string().length(6), z.string().length(36)]),
+  numAttemptsRemaining: z.number().int(),
+  createdAt: z.date(),
+  expiresAt: z.date(),
+});
+
 export type ExtendId<T extends any> = T & { _id: string };
 // For changing password
 export const changePWSchema = z.object({


### PR DESCRIPTION
Issue: #142 

This PR adds a generic model for verifications, including password reset and email verification. The schema is as follows:
```
{
  email: string;
  type: VerificationLogType; // either PASSWORD_RESET or EMAIL_VERIFICATION
  token: string;
  numAttemptsRemaining: number;
  createdAt: Date;
  expiresAt: Date;
}
```

Actions specific to password reset and email verification have also been added.
- For password reset:
  - Max. number of attempts is 5
  - Expiry date is set to 15 minutes from the time of creation
  - Token is a 6 digit number (like an OTP code)
- For email verification:
  - Max. number of attempts is infinite
  - Expiry date is set to 7 days from the time of creation 
  - Token is a 32-digit UUID