### PR TITLE
Added Password Reset Email Template

### DIFF
--- a/src/pages/api/email/index.ts
+++ b/src/pages/api/email/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 import { EmailInvalidInputException } from "@/utils/exceptions/email";
 import { contactSchema } from "@/utils/types";
-import { sendEmail } from "@/server/db/actions/EmailAction";
+import { sendContactEmail } from "@/server/db/actions/EmailAction";
 import z from "zod";
 export default async function handler(
   req: NextApiRequest,
@@ -24,7 +24,7 @@ async function sendEmailHandler(req: NextApiRequest, res: NextApiResponse) {
     if (!parsedData.success) {
       throw new EmailInvalidInputException(); //May need to modify this slightly
     }
-    await sendEmail(parsedData.data);
+    await sendContactEmail(parsedData.data);
     return res.status(HTTP_STATUS_CODE.OK).send("Succesfully sent email");
   } catch (e: any) {
     console.error(e);

--- a/src/server/db/actions/EmailAction.ts
+++ b/src/server/db/actions/EmailAction.ts
@@ -5,14 +5,22 @@ import { DEV_ADMIN_CONTACT } from "@/utils/consts";
 import { MailerSend, EmailParams, Sender, Recipient } from "mailersend";
 import { MAIL_SEND_DOMAIN } from "@/utils/consts";
 
-export async function sendEmail(data: ContactData) {
-  //Call user endpoint to get firstName, lastName, and email
-
-  const user = await getUser(data.userId); //This should def have a type
-
+export async function sendEmail(emailParams: EmailParams) {
   const mailerSend = new MailerSend({
     apiKey: process.env.MAILSEND_KEY || "",
   });
+
+  const result = await mailerSend.email.send(emailParams);
+  if (result.statusCode < 200 || result.statusCode >= 300) {
+    throw new EmailFailedToSendException();
+  }
+  return result;
+}
+
+export async function sendContactEmail(data: ContactData) {
+  //Call user endpoint to get firstName, lastName, and email
+  const user = await getUser(data.userId); //This should def have a type
+
   const sentFrom = new Sender(
     `randomemail@${MAIL_SEND_DOMAIN}`,
     `${user.firstName} ${user.lastName}`,
@@ -29,8 +37,26 @@ export async function sendEmail(data: ContactData) {
     .setReplyTo(replyBack)
     .setSubject(`Question about ${data.gameName}`)
     .setText(data.message);
-  const result = await mailerSend.email.send(emailParams);
-  if (result.statusCode < 200 || result.statusCode >= 300) {
-    throw new EmailFailedToSendException();
-  }
+
+  await sendEmail(emailParams);
+}
+
+export async function sendPasswordResetEmail(email: string, otpCode: string) {
+  const sentFrom = new Sender(`randomemail@${MAIL_SEND_DOMAIN}`);
+
+  const emailParams = new EmailParams()
+    .setFrom(sentFrom)
+    .setTo([new Recipient(email)])
+    .setSubject("Reset Your Password")
+    .setTemplateId(process.env.PASSWORD_RESET_TEMPLATE_ID || "")
+    .setPersonalization([
+      {
+        email: email,
+        data: {
+          otp_code: otpCode,
+        },
+      },
+    ]);
+
+  await sendEmail(emailParams);
 }


### PR DESCRIPTION
Issue: #142 
Related PR: #153 

This PR adds a function to send a password reset email using MailerSend. The [email template](https://app.mailersend.com/templates/show-builder/jpzkmgq6er24059v) is hosted on MailerSend itself (but I found it very easy to delete, so it might be a better idea to put it in the codebase).

The email currently looks like the following:
![image](https://github.com/user-attachments/assets/b30e38c8-9413-4b20-9d11-c5c45aa9ab96)

I have been unable to load the image on Gmail, and it is nearly impossible to get the Poppins font-family working so I used Inter.