### PR TITLE
cms dashboard day/week/month toggle and data fetching restructuring

### DIFF
--- a/src/components/Admin/CMSDashboard/PieChart.tsx
+++ b/src/components/Admin/CMSDashboard/PieChart.tsx
@@ -21,7 +21,7 @@ const PieChart: React.FC<PieChartProps> = ({ data, type }) => {
   const processed_data = data.map((item) => ({
     ...item,
     label:
-      item.label.length > 40 ? item.label.substring(0, 40) + "..." : item.label,
+      item.label.length > 40 ? item.label.substring(0, 35) + "..." : item.label,
   }));
 
   const totalCount = data.reduce((sum, item) => sum + item.value, 0);

--- a/src/pages/admin/cms-dashboard.tsx
+++ b/src/pages/admin/cms-dashboard.tsx
@@ -13,7 +13,6 @@ import { useAnalytics } from "@/context/AnalyticsContext";
 import { CustomVisitEvent } from "@/utils/types";
 import { EventEnvironment } from "bog-analytics";
 import { Spinner } from "@chakra-ui/react";
-import { set } from "mongoose";
 
 interface PieChartDataProps {
   id: string;
@@ -35,6 +34,77 @@ type GameData = {
   downloads: number;
   // plays: number; removed plays for now as it's not being logged
   userGroupsData: PieChartDataProps[];
+};
+
+const formatUserTrafficData = (
+  visitEvents: any[],
+): {
+  sourceData: PieChartDataProps[];
+  groupsData: PieChartDataProps[];
+} => {
+  // No data
+  if (!visitEvents || (visitEvents && visitEvents.length === 0)) {
+    const sourceData: PieChartDataProps[] = [];
+    const groupsData: PieChartDataProps[] = [];
+    return { sourceData, groupsData };
+  }
+
+  // SOURCE DATA
+  const referrerCount: Record<string, number> = {};
+
+  visitEvents.forEach((event: CustomVisitEvent) => {
+    const referrer = event.properties.referrer;
+    if (referrer in referrerCount) {
+      referrerCount[referrer]++;
+    } else {
+      referrerCount[referrer] = 1;
+    }
+  });
+
+  let referrerChartData = Object.entries(referrerCount).map(
+    ([referrer, count]) => ({
+      id: referrer,
+      label: referrer,
+      value: count,
+      ratio: ((count / visitEvents.length) * 100).toFixed(2),
+    }),
+  );
+  referrerChartData = referrerChartData.filter((data) => data.label != "None");
+  // We'll have to implement proper filtering later to remove local urls, but they're useful for testing
+
+  const sourceData = referrerChartData;
+
+  // GROUP DATA
+  const userGroupCount: Record<string, number> = {
+    Student: 0,
+    Educator: 0,
+    Parent: 0,
+    Admin: 0,
+  };
+
+  visitEvents.forEach((event: CustomVisitEvent) => {
+    const group = groupMap[event.properties.userGroup];
+    if (
+      group === "Student" ||
+      group === "Educator" ||
+      group === "Parent" ||
+      group === "Admin"
+    ) {
+      userGroupCount[group]++;
+    }
+  });
+
+  const groupChartData = Object.entries(userGroupCount).map(
+    ([group, count]) => ({
+      id: group,
+      label: group,
+      value: count,
+    }),
+  );
+
+  const groupsData = groupChartData;
+
+  return { sourceData, groupsData };
 };
 
 const formatGameEventsData = async (
@@ -182,12 +252,20 @@ const formatGameEventsData = async (
 
   return { gameData, leaderboardData };
 };
+
 const CMSDashboardPage = () => {
+  const [dataAge, setDataAge] = useState("day");
   const [selectedGameInfoRow, setSelectedGameInfoRow] = useState<number>(2);
   const itemsPerPage = 8;
 
   const { analyticsViewer } = useAnalytics();
   const [loading, setLoading] = useState(true);
+  const [trafficSourceData, setTrafficSourceData] = useState<
+    PieChartDataProps[]
+  >([]);
+  const [trafficGroupsData, setTrafficGroupsData] = useState<
+    PieChartDataProps[]
+  >([]);
   const [allGameData, setAllGameData] = useState<GameData[]>([]);
   const [userLeaderboard, setUserLeaderboard] = useState<
     UserLeaderboardEntry[][]
@@ -196,6 +274,36 @@ const CMSDashboardPage = () => {
   const getData = async () => {
     try {
       setLoading(true);
+
+      const afterTime = new Date();
+      switch (dataAge) {
+        case "day":
+          afterTime.setDate(afterTime.getDate() - 1);
+          break;
+        case "week":
+          afterTime.setDate(afterTime.getDate() - 7);
+          break;
+        case "month":
+          afterTime.setDate(afterTime.getDate() - 30);
+          break;
+      }
+
+      const visitQueryParams = {
+        projectName: "Jennifer Ann's",
+        environment: EventEnvironment.DEVELOPMENT,
+        category: "Visit",
+        subcategory: "Visit",
+        limit: 50000,
+        afterId: undefined,
+        afterTime: afterTime,
+      };
+      const visitEvents =
+        await analyticsViewer.getCustomEventsPaginated(visitQueryParams);
+
+      const { sourceData, groupsData } = formatUserTrafficData(
+        visitEvents?.events,
+      );
+
       const downloadQueryParams = {
         projectName: "Jennifer Ann's",
         environment: EventEnvironment.DEVELOPMENT,
@@ -218,23 +326,14 @@ const CMSDashboardPage = () => {
       const pdfEvents =
         await analyticsViewer.getCustomEventsPaginated(pdfQueryParams);
 
-      const visitQueryParams = {
-        projectName: "Jennifer Ann's",
-        environment: EventEnvironment.DEVELOPMENT,
-        category: "Visit",
-        subcategory: "Visit",
-        limit: 50000,
-        afterId: undefined,
-      };
-      const visitEvents =
-        await analyticsViewer.getCustomEventsPaginated(visitQueryParams);
-
       const { gameData, leaderboardData } = await formatGameEventsData(
         gameEvents?.events,
         pdfEvents?.events,
         visitEvents?.events,
       );
 
+      setTrafficSourceData(sourceData);
+      setTrafficGroupsData(groupsData);
       setAllGameData(gameData);
       setUserLeaderboard(leaderboardData);
     } catch (e) {
@@ -246,7 +345,7 @@ const CMSDashboardPage = () => {
 
   useEffect(() => {
     getData();
-  }, []);
+  }, [dataAge]); // re-fetch data when data age limit is changed
 
   useEffect(() => {
     const initialSelectedRow = selectedGameInfoRow;
@@ -310,36 +409,60 @@ const CMSDashboardPage = () => {
   return (
     <AdminTabs page={Pages.CMSDASHBOARD}>
       {/* prettier-ignore */}
-      <div className="bg-orange-light-bg my-6 flex items-stretch rounded-2xl p-12">
+      <div className="flex">
+          <button 
+            className={dataAge === "day" ? "p-6 text-orange-primary" : "p-6 text-black"}
+            onClick={() => setDataAge("day")}
+          >
+            Day
+          </button>
+          <button 
+            className={dataAge === "week" ? "p-6 text-orange-primary" : "p-6 text-black"}
+            onClick={() => setDataAge("week")}
+          >
+            Week
+          </button>
+          <button 
+            className={dataAge === "month" ? "p-6 text-orange-primary" : "p-6 text-black"}
+            onClick={() => setDataAge("month")}
+          >
+            Month
+          </button>
+        </div>
+      <div className="my-6 flex items-stretch rounded-2xl bg-orange-light-bg p-12">
         <div className="flex w-3/5 flex-col gap-6">
           <div className="rounded-2xl bg-white p-6 text-2xl text-black">
-            <UserTraffic />
+            <UserTraffic
+              trafficSourceData={trafficSourceData}
+              trafficGroupsData={trafficGroupsData}
+              loading={loading}
+            />
           </div>
           <div className="flex h-full flex-col rounded-2xl bg-white p-6 text-2xl text-black">
             <p>Game Info</p>
             <div className="flex-grow overflow-auto">
-              {loading ? 
-                  <div className="flex items-center justify-center py-10">
-                    <Spinner
-                      className="mb-5 h-10 w-10"
-                      thickness="4px"
-                      emptyColor="#98A2B3"
-                      color="#164C96"
-                    />
-                  </div>
-                  :  
-                  <PaginatedTable
-                    columns={GameInfoColumns}
-                    data={allGameData}
-                    itemsPerPage={itemsPerPage}
-                    setSelectedRow={setSelectedGameInfoRow}
-                    selectedRow={selectedGameInfoRow}
+              {loading ? (
+                <div className="flex items-center justify-center py-10">
+                  <Spinner
+                    className="mb-5 h-10 w-10"
+                    thickness="4px"
+                    emptyColor="#98A2B3"
+                    color="#164C96"
                   />
-              }
+                </div>
+              ) : (
+                <PaginatedTable
+                  columns={GameInfoColumns}
+                  data={allGameData}
+                  itemsPerPage={itemsPerPage}
+                  setSelectedRow={setSelectedGameInfoRow}
+                  selectedRow={selectedGameInfoRow}
+                />
+              )}
             </div>
           </div>
         </div>
-         {/* prettier-ignore */}
+        {/* prettier-ignore */}
         <div className="bg-orange-light-bg relative h-64 w-6">
           {/* White triangle to indicate which game's detailed info is being displayed */}
           <div
@@ -353,7 +476,7 @@ const CMSDashboardPage = () => {
           {allGameData[selectedGameInfoRow]?.gameTitle ?? ""}
           <div className="rounded-2xl border-[1px] border-orange-primary p-4 text-base text-black">
             User Groups
-            {loading ? 
+            {loading ? (
               <div className="flex items-center justify-center py-10">
                 <Spinner
                   className="mb-5 h-10 w-10"
@@ -362,13 +485,15 @@ const CMSDashboardPage = () => {
                   color="#164C96"
                 />
               </div>
-              :  
-              <UserGroupsByGame data={allGameData[selectedGameInfoRow]?.userGroupsData ?? []}/>
-            }
+            ) : (
+              <UserGroupsByGame
+                data={allGameData[selectedGameInfoRow]?.userGroupsData ?? []}
+              />
+            )}
           </div>
           <div className="flex flex-grow flex-col rounded-2xl border-[1px] border-orange-primary p-4 text-base text-black">
             <p>User Leaderboard</p>
-            {loading ? 
+            {loading ? (
               <div className="flex items-center justify-center py-10">
                 <Spinner
                   className="mb-5 h-10 w-10"
@@ -377,13 +502,13 @@ const CMSDashboardPage = () => {
                   color="#164C96"
                 />
               </div>
-              :  
+            ) : (
               <PaginatedTable
-              columns={UserLeaderboardColumns}
-              data={userLeaderboard[selectedGameInfoRow] ?? []}
-              itemsPerPage={itemsPerPage}
+                columns={UserLeaderboardColumns}
+                data={userLeaderboard[selectedGameInfoRow] ?? []}
+                itemsPerPage={itemsPerPage}
               />
-            }
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #183 

- Added day / week / month toggle option at the top of the page
- Note: It looks like only visit events can be filtered by date, not pdf and download - when I tried, it just returned an empty list
- Moved around some data fetching so it all happens in one place
<img width="877" alt="Screenshot 2024-10-31 at 10 34 34 PM" src="https://github.com/user-attachments/assets/55ebc5de-11ad-407c-a044-954630a04efa">
