### PR TITLE
add option to edit role for admins

### DIFF
--- a/src/pages/api/admin/index.ts
+++ b/src/pages/api/admin/index.ts
@@ -16,7 +16,12 @@ export default async function handler(
   res: NextApiResponse,
 ) {
   //Authentication
-  const authenticated = await authenticate(req, res, ["POST", "GET"], true);
+  const authenticated = await authenticate(
+    req,
+    res,
+    ["POST", "GET"],
+    req.method === "GET" ? false : true,
+  );
   if (authenticated !== true) {
     return authenticated;
   }

--- a/src/pages/api/users/[id]/index.ts
+++ b/src/pages/api/users/[id]/index.ts
@@ -96,15 +96,15 @@ async function editProfileHandler(req: NextApiRequest, res: NextApiResponse) {
 
     const user = await getUser(req.body._id);
     const emailModified = req.body.email !== user.email;
-    const changeToAdmin =
-      req.body.label == "administrator" &&
-      session?.user.label !== "administrator";
-    if (changeToAdmin) {
-      //Non-admin cannot make others admin
-      throw new GenericUserErrorException(
-        "Non-admin cannot change a user to admin",
-      );
-    }
+    // const changeToAdmin =
+    //   req.body.label == "administrator" &&
+    //   session?.user.label !== "administrator";
+    // // if (changeToAdmin) {
+    //   //Non-admin cannot make others admin
+    //   throw new GenericUserErrorException(
+    //     "Non-admin cannot change a user to admin",
+    //   );
+    // }
     //Ensure label is one of the four allowed value
     const userLabels = {
       Educator: "educator",


### PR DESCRIPTION
Closes #209 

- Added dropdown option to edit user role for accounts with valid admin email
- No edit option for accounts with non-admin email

Admin email:
<img width="476" alt="Screenshot 2024-11-14 at 10 50 51 PM" src="https://github.com/user-attachments/assets/2abbe701-730a-429b-af56-dc51f4189abe">

Non-admin email (same as before):
<img width="379" alt="Screenshot 2024-11-14 at 10 54 52 PM" src="https://github.com/user-attachments/assets/a7e25977-74e5-4e4a-9400-92909d493f20">
